### PR TITLE
Dismiss React warning

### DIFF
--- a/src/components/ModelessDialog.js
+++ b/src/components/ModelessDialog.js
@@ -49,6 +49,7 @@ class ModelessDialog extends React.Component {
 
 		const finalDialogStyle = Object.assign({}, defaultDialogStyle, style)
 		const finalBackdropStyle = Object.assign({}, defaultBackdropStyle, backdropStyle)
+		const handleCloseDialog = clickBackdropToClose ? this.close : undefined
 
 		return (
 			<div className={containerClassName}>
@@ -57,7 +58,7 @@ class ModelessDialog extends React.Component {
 				</div>
 				{!noBackdrop &&
 					<div className={backdropClassName} style={finalBackdropStyle}
-						onClick={clickBackdropToClose && this.close} />}
+						onClick={handleCloseDialog} />}
 			</div>
 		)
 	}


### PR DESCRIPTION
The PR is proposed to fix a warning when I use this wonderful component

> Warning: Expected `onClick` listener to be a function, instead got `false`.
> 
> If you used to conditionally omit it with onClick={condition && value}, pass onClick={condition ? value : undefined} instead.